### PR TITLE
Use 'hostname' and 'port' config values

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,8 @@ Install by running::
 Setup your beets host
 
     [beets]
-    host = "http://yourserver:port"
+    hostname = 127.0.0.1
+    port = 8888
 
 
 

--- a/mopidy_beets/__init__.py
+++ b/mopidy_beets/__init__.py
@@ -42,12 +42,9 @@ class BeetsExtension(ext.Extension):
 
     def get_config_schema(self):
         schema = super(BeetsExtension, self).get_config_schema()
-        schema['hostname'] = config.String()
+        schema['hostname'] = config.Hostname()
+        schema['port'] = config.Port()
         return schema
-
-    def validate_config(self, config):
-        if not config.getboolean('beets', 'enabled'):
-            return
 
     def validate_environment(self):
         try:

--- a/mopidy_beets/actor.py
+++ b/mopidy_beets/actor.py
@@ -15,7 +15,11 @@ class BeetsBackend(pykka.ThreadingActor, base.Backend):
 
     def __init__(self, config, audio):
         super(BeetsBackend, self).__init__()
-        self.beets_api = BeetsRemoteClient(config['beets']['hostname'])
+
+        beets_endpoint = 'http://%s:%s' % (
+            config['beets']['hostname'], config['beets']['port'])
+
+        self.beets_api = BeetsRemoteClient(beets_endpoint)
         self.library = BeetsLibraryProvider(backend=self)
         self.playback = BeetsPlaybackProvider(audio=audio, backend=self)
         self.playlists = None

--- a/mopidy_beets/ext.conf
+++ b/mopidy_beets/ext.conf
@@ -1,4 +1,4 @@
 [beets]
-enabled = True
-hostname = 
-
+enabled = true
+hostname = 127.0.0.1
+port = 8888


### PR DESCRIPTION
- Fixes example in README, which didn't match actual config
- Using separate config values for hostname and port increases consistency with
  other Mopidy extensions, and it also matches the config of Beets' web plugin
