### PR TITLE
Use GitHub Actions to release to PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
+    - name: "Install dependencies"
+      run: python3 -m pip install build
+    - name: "Build package"
+      run: python3 -m build
+    - uses: pypa/gh-action-pypi-publish@v1.4.1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_TOKEN }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,8 +41,8 @@ lint =
     flake8-import-order
     isort[pyproject]
 release =
+    build
     twine
-    wheel
 test =
     pytest
     pytest-cov


### PR DESCRIPTION
I've already set the `PYPI_TOKEN` secret on this repo, so with this change,
anyone with commit access should be able to create releases of this extension
by following the procedure at:

https://docs.mopidy.com/en/develop/releasing/#releasing-extensions

FYI @sumpfralle
