### PR TITLE
Add support for exposing cover art via `library.get_images()`

### DIFF
--- a/mopidy_beets/client.py
+++ b/mopidy_beets/client.py
@@ -200,7 +200,7 @@ class BeetsRemoteClient(object):
 
     @cache()
     def get_artists(self):
-        """ returns all artists of one or more tracks """
+        """returns all artists of one or more tracks"""
         names = self._get("/artist/")["artist_names"]
         names.sort()
         # remove empty names
@@ -216,7 +216,7 @@ class BeetsRemoteClient(object):
 
     @cache(ctl=32)
     def _get_unique_attribute_values(self, base_url, field, sort_field):
-        """ returns all artists, genres, ... of tracks or albums """
+        """returns all artists, genres, ... of tracks or albums"""
         if not hasattr(self, "__legacy_beets_api_detected"):
             try:
                 result = self._get(

--- a/mopidy_beets/library.py
+++ b/mopidy_beets/library.py
@@ -177,6 +177,15 @@ class BeetsLibraryProvider(backend.LibraryProvider):
             # the newer method (mopidy>=1.0): return a dict of uris and tracks
             return {uri: self.lookup(uri=uri) for uri in uris}
 
+    def get_images(self, uris):
+        images = {}
+        for uri in uris:
+            path, item_id = parse_uri(uri, uri_prefix=self.root_directory.uri)
+            if path == "album" and isinstance(item_id, int):
+                url = self.remote.get_album_art_url(item_id)
+                images[uri] = [models.Image(uri=url)]
+        return images
+
     def get_distinct(self, field, query=None):
         logger.debug("Beets distinct query: %s (uri=%s)", field, query)
         if not self.remote.has_connection:


### PR DESCRIPTION
Adds a new method to `mopidy_beets/library.py` to expose cover art via [mopidy.backend.LibraryProvider.get_images()](https://docs.mopidy.com/en/latest/api/backend/#mopidy.backend.LibraryProvider.get_images), as also requested in [@28. ](https://github.com/mopidy/mopidy-beets/issues/28).

In addition, reformat `mopidy_beets/client.py` with black.