### PR TITLE
Library: fix search with date argument

### DIFF
--- a/mopidy_beets/library.py
+++ b/mopidy_beets/library.py
@@ -135,7 +135,7 @@ class BeetsLibraryProvider(backend.LibraryProvider):
         tracks = self.remote.get_tracks_by(search_list, exact, [])
         uri = "-".join(
             [
-                item if isinstance(item, str) else "=".join(item)
+                item if isinstance(item, str) else "=".join(map(str, item))
                 for item in search_list
             ]
         )


### PR DESCRIPTION
If a query was made for eg. `date: 2025`, date parsing would add `('year', 2025)` to `search_list`, 2025 being an integer. The uri generation later would fail trying to `'='.join(('year', 2025))` as join needs an iterable of strings.