### PR TITLE
fix: Make browsing by album genre work with Beets 2.x

### DIFF
--- a/src/mopidy_beets/client.py
+++ b/src/mopidy_beets/client.py
@@ -188,6 +188,10 @@ class BeetsRemoteClient:
         return self._get_unique_attribute_values("/item", field, sort_field)
 
     def get_sorted_unique_album_attributes(self, field):
+        # Modern Beets exposes the multi-valued "genres" on albums (singular
+        # "genre" was removed after the 2.x series); fall through to the
+        # plural key so both /album/values/... and the legacy fallback work.
+        field = {"genre": "genres"}.get(field, field)
         sort_field = {"albumartist": "albumartist_sort"}.get(field, field)
         return self._get_unique_attribute_values("/album", field, sort_field)
 

--- a/tests/helper_beets.py
+++ b/tests/helper_beets.py
@@ -127,7 +127,12 @@ class BeetsAPILibraryTest(MopidyBeetsTest):
                         args[key] = fallback_value
                 new_item = self.beets.add_item_fixture(**args)
                 album_items.append(new_item)
-            self.beets.lib.add_album(album_items)
+            beets_album = self.beets.lib.add_album(album_items)
+            if album.genre:
+                # Modern Beets tracks genres on albums as a multi-valued list;
+                # populate it so browsing by genre finds the album.
+                beets_album["genres"] = [album.genre]
+                beets_album.store()
 
     def tearDown(self):
         self.beets.stop()


### PR DESCRIPTION
Triggered by tests failing due to changes to Beets' test helpers.